### PR TITLE
Remove .config.json dependency

### DIFF
--- a/helpers/GoogleHelper.php
+++ b/helpers/GoogleHelper.php
@@ -4,15 +4,34 @@ namespace rapidweb\googlecontacts\helpers;
 
 abstract class GoogleHelper
 {
+    private static $_config;
+
+    public static function initConfig(
+        $clientID,
+        $clientSecret,
+        $redirectUri,
+        $developerKey,
+        $refreshToken
+    ) {
+        self::$_config = [
+            'clientID' => $clientID,
+            'clientSecret' => $clientSecret,
+            'redirectUri' => $redirectUri,
+            'developerKey' => $developerKey,
+            'refreshToken' => $refreshToken,
+        ];
+    }
+
     private static function loadConfig()
     {
-        die(var_dump('test'));
-        $configPath = __DIR__.'/../../../../.config.json';
-        if(!file_exists($configPath)) throw new \Exception('Not found config.json');
-        $contents = file_get_contents($configPath);
-        $config = json_decode($contents);
+        if (NULL === self::$_config) {
+            $configPath = __DIR__.'/../../../../.config.json';
+            if(!file_exists($configPath)) throw new \Exception('Not found config.json');
+            $contents = file_get_contents($configPath);
+            self::$_config = json_decode($contents);
+        }
 
-        return $config;
+        return self::$_config;
     }
 
     public static function getClient()

--- a/helpers/GoogleHelper.php
+++ b/helpers/GoogleHelper.php
@@ -6,6 +6,7 @@ abstract class GoogleHelper
 {
     private static function loadConfig()
     {
+        die(var_dump('test'));
         $configPath = __DIR__.'/../../../../.config.json';
         if(!file_exists($configPath)) throw new \Exception('Not found config.json');
         $contents = file_get_contents($configPath);

--- a/helpers/GoogleHelper.php
+++ b/helpers/GoogleHelper.php
@@ -13,13 +13,12 @@ abstract class GoogleHelper
         $developerKey,
         $refreshToken
     ) {
-        self::$_config = [
-            'clientID' => $clientID,
-            'clientSecret' => $clientSecret,
-            'redirectUri' => $redirectUri,
-            'developerKey' => $developerKey,
-            'refreshToken' => $refreshToken,
-        ];
+        self::$_config = new \stdClass();
+        self::$_config->clientID = $clientID;
+        self::$_config->clientSecret = $clientSecret;
+        self::$_config->redirectUri = $redirectUri;
+        self::$_config->developerKey = $developerKey;
+        self::$_config->refreshToken = $refreshToken;
     }
 
     private static function loadConfig()


### PR DESCRIPTION
This patch allows any user to specify the Google Client parameters via a static method, removing the need to create the .config.json file.

This allows the use of the library to be more dynamic, for instance you can now use it in conjunction with the official Google PHP API, using that one to authenticate instead of the php files included in this library