### PR TITLE
Remove StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,2 +1,0 @@
-disabled:
-  - short_array_syntax


### PR DESCRIPTION
Removes the repository-level StyleCI configuration. StyleCI is no longer part of the maintenance workflow.